### PR TITLE
APAAS-2667-app-stacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ cflinuxfs2.cid: cflinuxfs2/Dockerfile
 	docker build --no-cache -t cloudfoundry/cflinuxfs2 cflinuxfs2
 	docker run --cidfile=cflinuxfs2.cid cloudfoundry/cflinuxfs2 dpkg -l | tee cflinuxfs2/cflinuxfs2_dpkg_l.out
 
-cflinuxfs2.tar: cflinuxfs2.cid
+tmp/cflinuxfs2.tar: cflinuxfs2.cid
 	mkdir -p tmp
-	docker export `cat cflinuxfs2.cid` > tmp/cflinuxfs2.tar
+	docker export `cat cflinuxfs2.cid` > $@
 	# Always remove the cid file in order to grab updated package versions.
 	rm cflinuxfs2.cid
 
-cflinuxfs2.tar.gz: cflinuxfs2.tar
+cflinuxfs2.tar.gz: tmp/cflinuxfs2.tar
 	./bin/make_tarball.sh cflinuxfs2

--- a/bin/make_tarball.sh
+++ b/bin/make_tarball.sh
@@ -1,17 +1,8 @@
 #!/bin/bash
 
-make_tarball="
-	mkdir -p tmp/$1/etc
-	cp $1/assets/etc/hosts tmp/$1/etc/hosts
-	cp $1/assets/etc/timezone tmp/$1/etc/timezone
-	tar -C tmp/$1 -xf tmp/${1}.tar
-	ls tmp/$1/ | xargs tar -C tmp/$1 -czf ${1}.tar.gz
-	rm -rf tmp/$1
-"
-
-if [ "$(uname)" == "Darwin" ]; then
-  sudo bash -c "$make_tarball"
-  sudo chmod a+rw ${1}.tar.gz
-else
-  bash -c "$make_tarball"
-fi
+mkdir -p tmp/$1/etc
+cp $1/assets/etc/hosts tmp/$1/etc/hosts
+cp $1/assets/etc/timezone tmp/$1/etc/timezone
+TAR=bsdtar
+which bsdtar &>/dev/null || TAR=tar
+${TAR} -C tmp/$1 -czf ${1}.tar.gz etc @../${1}.tar

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -18,6 +18,7 @@ ADD assets /tmp/assets
 RUN bash /tmp/build/configure-locale-timezone.sh
 RUN bash /tmp/build/install-packages.sh
 RUN bash /tmp/build/install-ruby.sh 1.9.3-p547
+RUN bash /tmp/build/stackato-save-env.sh
 RUN bash /tmp/build/configure-core-dump-directory.sh
 RUN bash /tmp/build/configure-firstboot.sh
 RUN bash /tmp/build/configure-sshd.sh

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -20,6 +20,7 @@ RUN bash /tmp/build/install-packages.sh
 RUN bash /tmp/build/install-ruby.sh 1.9.3-p547
 RUN bash /tmp/build/configure-core-dump-directory.sh
 RUN bash /tmp/build/configure-firstboot.sh
+RUN bash /tmp/build/configure-sshd.sh
 RUN bash /tmp/build/diego-prep.sh
 
 # create the vcap for garden and warden

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -18,4 +18,6 @@ RUN useradd -mU -s /bin/bash vcap
 # /app must exist so we can bind-mount it to /home/vcap in seed
 RUN mkdir /app
 
+RUN cp /tmp/assets/etc/timezone /etc/timezone
+
 RUN rm -rf /tmp/*

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:trusty
 
+ADD stackon.json /
+
 ADD build /tmp/build
 ADD assets /tmp/assets
 

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -10,7 +10,7 @@ ADD regenerate-timezone-data \
 
 RUN mkdir -p /var/run/sshd && chmod 0755 /var/run/sshd
 
-ENV HCF_LOG_FILES stdout=/home/stackato/logs/stdout.log:stderr=/home/stackato/logs/stderr.log
+ENV STACKATO_LOG_FILES stdout=/home/stackato/logs/stdout.log:stderr=/home/stackato/logs/stderr.log
 
 ADD build /tmp/build
 ADD assets /tmp/assets

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -10,6 +10,8 @@ ADD regenerate-timezone-data \
 
 RUN mkdir -p /var/run/sshd && chmod 0755 /var/run/sshd
 
+ENV HCF_LOG_FILES stdout=/home/stackato/logs/stdout.log:stderr=/home/stackato/logs/stderr.log
+
 ADD build /tmp/build
 ADD assets /tmp/assets
 

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu:trusty
 
 ADD stackon.json /
+ADD regenerate-timezone-data \
+    stack-add-repo stack-install-package stack-update-repos \
+    /usr/local/bin/
+
 
 ADD build /tmp/build
 ADD assets /tmp/assets
@@ -21,3 +25,5 @@ RUN mkdir /app
 RUN cp /tmp/assets/etc/timezone /etc/timezone
 
 RUN rm -rf /tmp/*
+
+CMD ["/start.sh"]

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -1,10 +1,11 @@
 FROM ubuntu:trusty
 
-ADD stackon.json /
+ADD start.sh stackon.json /
 ADD regenerate-timezone-data \
     stack-add-repo stack-install-package stack-update-repos \
     /usr/local/bin/
 
+RUN mkdir -p /var/run/sshd && chmod 0755 /var/run/sshd
 
 ADD build /tmp/build
 ADD assets /tmp/assets

--- a/cflinuxfs2/Dockerfile
+++ b/cflinuxfs2/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:trusty
 
+# expose ssh
+EXPOSE 22
+
 ADD start.sh stackon.json /
 ADD regenerate-timezone-data \
     stack-add-repo stack-install-package stack-update-repos \

--- a/cflinuxfs2/build.sh
+++ b/cflinuxfs2/build.sh
@@ -1,0 +1,17 @@
+# Build the Dockerfile
+# Return the name of the image
+# e.g. IMAGE=$()
+set -e # Exit on errors
+
+docker_image_name="stackato/stack-cflinuxfs2" 
+git_branch="$(git rev-parse --abbrev-ref HEAD)"
+git_short_hash="$(git rev-parse --short HEAD)"
+
+docker_tag=${docker_image_name}:${git_branch}-${git_short_hash}
+
+if docker build --rm=true --tag="${docker_tag}" . 1>&2; then
+        echo ${docker_tag}
+else
+	exit 1
+fi
+

--- a/cflinuxfs2/build/configure-sshd.sh
+++ b/cflinuxfs2/build/configure-sshd.sh
@@ -1,0 +1,7 @@
+set -e -x
+
+sed -i "s/AcceptEnv /AcceptEnv HCF_* /" /etc/ssh/sshd_config
+
+echo | tee --append /etc/ssh/sshd_config
+echo "UseDNS no" | tee --append /etc/ssh/sshd_config
+echo | tee --append /etc/ssh/sshd_config

--- a/cflinuxfs2/build/configure-sshd.sh
+++ b/cflinuxfs2/build/configure-sshd.sh
@@ -1,6 +1,6 @@
 set -e -x
 
-sed -i "s/AcceptEnv /AcceptEnv HCF_* /" /etc/ssh/sshd_config
+sed -i "s/AcceptEnv /AcceptEnv STACKATO_* /" /etc/ssh/sshd_config
 
 echo | tee --append /etc/ssh/sshd_config
 echo "UseDNS no" | tee --append /etc/ssh/sshd_config

--- a/cflinuxfs2/build/install-packages.sh
+++ b/cflinuxfs2/build/install-packages.sh
@@ -29,6 +29,7 @@ gsfonts
 imagemagick
 iputils-arping
 krb5-user
+jq
 laptop-detect
 less
 libaio1

--- a/cflinuxfs2/build/stackato-save-env.sh
+++ b/cflinuxfs2/build/stackato-save-env.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Prepare the docker image before commiting.
+set -ex
+
+mkdir -p /etc/stackato/
+
+# Save image env at /etc/stackato, for it won't be available to ssh clients
+env > /etc/stackato/image.env
+# Save a JSON version.
+python -c "import os,json; print json.dumps(os.environ.copy())" > /etc/stackato/image.env.json
+

--- a/cflinuxfs2/jenkins-wrapper.sh
+++ b/cflinuxfs2/jenkins-wrapper.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e # Exit on errors
+IMAGE_NAME=$(./build.sh)
+
+if [ "$PUSH_IMAGE" == "true" ]; then
+        : ${DOCKER_REGISTRY?"Need to set DOCKER_REGISTRY (e.g. export REGISTRY_USERNAME=address of your docker-registry)"}
+        ./push.sh $IMAGE_NAME $DOCKER_REGISTRY
+fi
+

--- a/cflinuxfs2/push.sh
+++ b/cflinuxfs2/push.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e # Exit on errors
+
+# Tag your local image to DOCKER_REGISTERY/image and push it
+: ${EMAIL?"Need to set EMAIL (e.g. export EMAIL=username@stackato.com)"}
+: ${REGISTRY_USERNAME?"Need to set REGISTRY_USERNAME (e.g. export REGISTRY_USERNAME=your_username)"}
+: ${REGISTRY_PASSWORD?"Need to set REGISTRY_PASSWORD (e.g. export REGISTRY_PASSWORD=your_password)"}
+
+image="$1"           # Name of the image to push
+docker_registry="$2" # Address of the docker registry
+
+# Check if a docker registry is already in the image name
+if echo ${image} | grep --quiet ${docker_registry}; then
+        >&2 echo "Docker registry ${docker_registry} found in the image $image"
+        exit 1
+fi
+
+docker tag ${image} ${docker_registry}/${image}
+docker login --email="$EMAIL" --username="$REGISTRY_USERNAME" --password="$REGISTRY_PASSWORD" $docker_registry
+docker push ${docker_registry}/${image}
+

--- a/cflinuxfs2/regenerate-timezone-data
+++ b/cflinuxfs2/regenerate-timezone-data
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# /etc/timezone has been changed, so /etc/localtime needs to be regenerated
+dpkg-reconfigure --frontend noninteractive tzdata

--- a/cflinuxfs2/stack-add-repo
+++ b/cflinuxfs2/stack-add-repo
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+os=${1:-}
+repo=${2:-}
+
+if [[ -z "$os" || -z "$repo" ]]
+then
+  echo "usage: $0 ubuntu repo"
+  exit 1
+fi
+
+if [[ "ubuntu" == "$os" ]]
+then
+  /usr/bin/add-apt-repository "$repo"
+fi

--- a/cflinuxfs2/stack-install-package
+++ b/cflinuxfs2/stack-install-package
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+os=${1:-}
+
+if [[ -z "$os" || -z "${2:-}" ]]
+then
+  echo "usage: $0 ubuntu package <package2...N>"
+  exit 1
+fi
+
+if [[ "ubuntu" == "$os" ]]
+then
+  DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y install -- "${@:2}"
+fi

--- a/cflinuxfs2/stack-install-package
+++ b/cflinuxfs2/stack-install-package
@@ -10,6 +10,24 @@ then
   exit 1
 fi
 
+# Skip if allow_sudo is enabled
+if ! grep -q '^stackato ALL= NOPASSWD: ALL' /etc/sudoers; then
+  for i in "${@:2}"
+  do
+    # Check if package name ends with '-', this means package removal in apt-get
+    if [[ "$i" == *- ]] ; then
+      echo "Package removal requires allow_sudo"
+      exit 2
+    fi
+
+    # Don't allow installing older, potentially vulnerable packages
+    if [[ "${i/=}" != "$i" ]] ; then
+      echo "Installing specific versions requires allow_sudo access"
+      exit 3
+    fi
+  done
+fi
+
 if [[ "ubuntu" == "$os" ]]
 then
   DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get -y install -- "${@:2}"

--- a/cflinuxfs2/stack-update-repos
+++ b/cflinuxfs2/stack-update-repos
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+for i in "$@";
+do
+  if [[ $i == 'ubuntu' ]];
+  then
+    /usr/bin/apt-get -y update
+  fi
+done
+

--- a/cflinuxfs2/stackon.json
+++ b/cflinuxfs2/stackon.json
@@ -1,0 +1,3 @@
+{
+  "name": "stackato/stack-cflinuxfs2"
+}

--- a/cflinuxfs2/start.sh
+++ b/cflinuxfs2/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+echo "Launching ssh at: `date`"
+exec /usr/sbin/sshd -D -e -o LogLevel=INFO


### PR DESCRIPTION
Create a stackato/stack-cflinuxfs2 image that is compatible with the app stack support in Stackato.

This PR is based of the 1.0.1 tag and not master.  The newer commits on master are all related to diego compatibility and should not be relevant to Stackato.

The PR is against the stackato branch, and not against master because we want to keep the master branch identical to upstream for HCF related work.
